### PR TITLE
Fix path pattern for rephased VCF files

### DIFF
--- a/modules/local/wakhan/environment.yml
+++ b/modules/local/wakhan/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::wakhan=0.1.1"
+  - "bioconda::wakhan=0.4.2"

--- a/modules/local/wakhan/main.nf
+++ b/modules/local/wakhan/main.nf
@@ -32,8 +32,8 @@ process WAKHAN {
     tuple val(meta), path("coverage_plots/*.pdf")                               , emit: coverage_plots_pdf
     tuple val(meta), path("phasing_output/*.html")                              , emit: phasing_html
     tuple val(meta), path("phasing_output/*.pdf")                               , emit: phasing_pdf
-    tuple val(meta), path("phasing_output/*.rephased.vcf.gz")                   , emit: rephased_vcf
-    tuple val(meta), path("phasing_output/*.rephased.vcf.gz.csi")               , emit: rephased_vcf_index
+    tuple val(meta), path("phasing_output/*rephased.vcf.gz")                    , emit: rephased_vcf
+    tuple val(meta), path("phasing_output/*rephased.vcf.gz.csi")                , emit: rephased_vcf_index
     tuple val(meta), path("snps_loh_plots/*_genome_snps_ratio_loh.html")        , emit: snps_loh_plot,      optional: true
     tuple val(meta), path("solutions_ranks.tsv")                                , emit: solutions_ranks
     // WARN: Manually update version information as tool does not provide on CLI

--- a/modules/local/wakhan/main.nf
+++ b/modules/local/wakhan/main.nf
@@ -3,9 +3,9 @@ process WAKHAN {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/wakhan:0.2.0--pyhdfd78af_1':
-        'biocontainers/wakhan:0.2.0--pyhdfd78af_1' }"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?  
+        'https://depot.galaxyproject.org/singularity/wakhan:0.4.2--pyhdfd78af_0':  
+        'biocontainers/wakhan:0.4.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(tumor_input), path(tumor_index), path(normal_input), path(normal_index), path(vcf), path(breakpoints)

--- a/modules/local/wakhan/main.nf
+++ b/modules/local/wakhan/main.nf
@@ -3,8 +3,8 @@ process WAKHAN {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?  
-        'https://depot.galaxyproject.org/singularity/wakhan:0.4.2--pyhdfd78af_0':  
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/wakhan:0.4.2--pyhdfd78af_0':
         'biocontainers/wakhan:0.4.2--pyhdfd78af_0' }"
 
     input:


### PR DESCRIPTION
Missing output file(s) `phasing_output/*.rephased.vcf.gz` expected by process `INTGENOMICSLAB_LRSOMATIC:LRSOMATIC:WAKHAN

The WAKHAN is generating /rephased.vcf.gz and /rephased.vcf.gz.csi
Just incase, I preserved the * for other potential matching
#128 

## PR checklist

- [x] This comment contains a description of changes (with reason).
