### PR TITLE
add --vcf to default vep_args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.2.0dev
+
+### `Fixed`
+
+- [#182](https://github.com/IntGenomicsLab/lrsomatic/pull/182) - Added `--vcf` to the default `vep_args` so VEP writes VCF output rather than its default tab-delimited format (@AmberVerhasselt).
+
 ## v1.1.0 - [2026-04-28]
 
 ### `Added`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -164,7 +164,7 @@ If you want to run with a CHM13 reference without using `--genome CHM13` (for ex
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--vep_cache`          | Full path to a vep cache. If left blank, this will default to pulling from this [Annotation Cache Storage](https://annotation-cache.github.io/). |
 | `--vep_cache_version`  | Integer specifying version of vep cache. Default = `113`                                                                                         |
-| `--vep_args`           | A string specifying arguments to vep. Default = `"--everything --filter_common --per_gene --total_length --offline --format vcf"`                |
+| `--vep_args`           | A string specifying arguments to vep. Default = `"--everything --filter_common --per_gene --total_length --offline --format vcf --vcf"`          |
 | `--vep_custom`         | A full path to a vcf file containing custom variants for annotation. Must be bgzipped and have `.vcf.gz` format. Default = `null`                |
 | `--vep_custom_tbi`     | A full path to a index file for cutom vcf for vep. Default = `null`                                                                              |
 | `--download_vep_cache` | A boolean to automatically download the VEP cache if not found locally. Default = `false`                                                        |

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,7 +39,7 @@ params {
     vep_cache                   = 's3://annotation-cache/vep_cache/'
     vep_cache_version           = 113
     download_vep_cache          = false
-    vep_args                    = "--everything --filter_common --per_gene --total_length --offline --format vcf"
+    vep_args                    = "--everything --filter_common --per_gene --total_length --offline --format vcf --vcf"
     vep_custom                  = null
     vep_custom_tbi              = null
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -197,7 +197,7 @@
                     "type": "string",
                     "description": "Additional command line arguments to pass to VEP.",
                     "fa_icon": "fas fa-terminal",
-                    "default": "--everything --filter_common --per_gene --total_length --offline --format vcf"
+                    "default": "--everything --filter_common --per_gene --total_length --offline --format vcf --vcf"
                 },
                 "vep_cache_version": {
                     "type": "integer",


### PR DESCRIPTION
## What

Adds `--vcf` to the default `vep_args`.

## Why

`--format vcf` describes VEP's **input** format; `--vcf` selects its **output** format. These are two
different flags, and only the first was being passed.

Without `--vcf`, VEP writes its default **tab-delimited** output. The module still names the file
`*_VEP.vcf.gz`, because the file-extension ternary in
[`modules/nf-core/ensemblvep/vep/main.nf#L37`](https://github.com/IntGenomicsLab/lrsomatic/blob/dev/modules/nf-core/ensemblvep/vep/main.nf#L37)

```groovy
def file_extension = args.contains("--vcf") ? 'vcf' : args.contains("--json") ? 'json' : args.contains("--tab") ? 'tab' : 'vcf'
```

falls through to its trailing `'vcf'` fallback — `"--format vcf"` does not contain the substring
`--vcf` (there is a space). So every published VEP file is named `.vcf.gz` while actually being a tab
file, and `tabix` (line 42, gated on the same `file_extension`) is run against it.

This has a concrete downstream cost. The tab format re-encodes coordinates into VEP's own
`Uploaded_variation` identifier, and that encoding changed between Ensembl 114 and 115:

| Ensembl | VCF record | `Uploaded_variation` |
| --- | --- | --- |
| 114 | `chr1 1904021 TG>T` | `chr1_1904023_G/-` (normalised, trimmed, `-` for empty side) |
| 115 | `chr1 1904021 TG>T` | `chr1_1904022_TG/T` (raw alleles, position +1) |

SNV identifiers are identical under both conventions, so only **indels** break. Any analysis joining
the annotation back to the caller VCF on that identifier silently loses every insertion and deletion —
in a cohort here that was ~150 indels (98 HIGH / 9 MODERATE / 43 LOW impact), dropped with no error
because the unmatched rows just carried `NA` gene/impact and were then removed by a gene-list filter.

With `--vcf`, VEP echoes the original `CHROM/POS/REF/ALT` line verbatim and puts annotation in
`INFO/CSQ`. There is no identifier to reconstruct, so nothing to normalise or mis-normalise, and the
problem class disappears rather than being patched around.

## Impact

- Affects published-file **content** only. All three VEP calls (`SOMATIC_VEP`, `GERMLINE_VEP`,
  `SV_VEP`) are leaves of the DAG — nothing in the pipeline consumes their output.
- Output **filenames and paths are unchanged**: `file_extension` was already resolving to `'vcf'` via
  the fallback, so `*_VEP.vcf.gz` / `.tbi` / `_summary.html` are all named exactly as before. No
  snapshot updates required (VEP output content is excluded by `tests/.nftignore`, and the recorded
  `ensemblvep` version is unaffected).
- `tabix`, which the module already runs, now operates on a genuine VCF.
- Users overriding `--vep_args` on the command line need to include `--vcf` themselves, as with any
  other default in this pipeline.

The default is kept byte-identical across `nextflow.config`, `nextflow_schema.json` and
`docs/usage.md`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Documentation in `docs` is updated (`docs/usage.md`). `docs/output.md` needs no change —
      filenames and layout are unchanged.
- [x] `CHANGELOG.md` is updated.
- [ ] Make sure your code lints — `nextflow-lint` could not be run locally (no `nextflow` binary on
      the cluster this was authored on); prettier / trailing-whitespace / end-of-file hooks pass.
- [ ] `nf-test` not run locally (no docker/nf-test available here); relying on CI.
