### PR TITLE
Fix Clair3 model download staging when explicit override bypasses aut…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#182](https://github.com/IntGenomicsLab/lrsomatic/pull/182) - Added `--vcf` to the default `vep_args` so VEP writes VCF output rather than its default tab-delimited format (@AmberVerhasselt).
+- [#191](https://github.com/IntGenomicsLab/lrsomatic/pull/191) - Fixed Clair3 model download staging so an explicit `clair3_model` override works when the auto-detected basecall model is missing or not in the model map (@YannVRB).
 
 ## v1.1.0 - [2026-04-28]
 

--- a/subworkflows/local/prepare_reference_files.nf
+++ b/subworkflows/local/prepare_reference_files.nf
@@ -49,9 +49,15 @@ workflow PREPARE_REFERENCE_FILES {
         // Priority: explicit meta.clair3_model param > auto-detected from BAM header via modelMap
         // PacBio models from HKU mirror; ONT models from Oxford Nanopore CDN
         basecall_meta.map { meta, basecall_model_meta, _kinetics_meta ->
-            def id_new = basecall_model_meta ? clair3_modelMap.get(basecall_model_meta) : basecall_model_meta
-            def meta_new = [id: id_new]
+            // model resolves to the samplesheet's explicit override first, falling back to the
+            // modelMap lookup from the auto-detected basecall model. meta_new.id reuses this same
+            // value (rather than recomputing it from basecall_model_meta alone) so the WGET/UNTAR
+            // staging directory name never diverges from the model actually being downloaded --
+            // previously it could resolve to null (and UNTAR would fail with "mkdir: missing
+            // operand") whenever basecall_model_meta didn't match the modelMap, even if an
+            // explicit clair3_model override was given.
             def model = (!meta.clair3_model || meta.clair3_model.toString().trim() in ['', '[]']) ? clair3_modelMap.get(basecall_model_meta) : meta.clair3_model
+            def meta_new = [id: model]
             def download_prefix = ( basecall_model_meta == 'hifi_revio' ? "https://www.bio8.cs.hku.hk/clair3/clair3_models/" : "https://cdn.oxfordnanoportal.com/software/analysis/models/clair3" )
             def url = "${download_prefix}/${model}.tar.gz"
             return [ meta_new, url ]


### PR DESCRIPTION
…o-detection

PREPARE_REFERENCE_FILES computed the WGET/UNTAR staging directory name (meta_new.id) independently from the actual download URL (model): the URL correctly fell back to the samplesheet's explicit clair3_model override when basecall_model_meta didn't match clair3_modelMap, but the staging id did not -- it was only ever clair3_modelMap.get(basecall_model_meta), which resolves to null on any unmapped model. UNTAR then failed with "mkdir: missing operand" because its output directory name came out empty, even though the model itself downloaded successfully under the correct override.

This isn't specific to any one basecall model -- it triggers for any sample whose auto-detected basecall_model_meta isn't in clair3_modelMap (currently only dna_r10.4.1_e8.2_*_sup@v4.x/v5.x and hifi_revio are mapped), whether that's because the model genuinely isn't supported yet, or because BAM header metadata is missing/malformed. H

Fix: derive meta_new.id from the same resolved `model` value used for the download URL, so an explicit clair3_model override always works regardless of whether the auto-detected model has a modelMap entry.


Claude-Session: https://claude.ai/code/session_01DhE7yZ2qRjaG86P7JgZbA4

<!--
# IntGenomicsLab/lrsomatic pull request

Many thanks for contributing to IntGenomicsLab/lrsomatic!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/IntGenomicsLab/lrsomatic/tree/main/docs/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/IntGenomicsLab/lrsomatic/tree/main/docs/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
